### PR TITLE
itms support should mean we keep HTTP(s)

### DIFF
--- a/ios-url-schemes/plugin.php
+++ b/ios-url-schemes/plugin.php
@@ -26,7 +26,7 @@ yourls_add_filter( 'is_allowed_protocol', 'suculent_itms_protocols' );
 
 function suculent_itms_protocols( $args, $url ) {
 	/* List of protocols added by this plugin */
-	$protocols = array( 'itms-services://', 'itms-apps://');
+	$protocols = array( 'itms-services://', 'itms-apps://', 'http://', 'https://');
 	
 	/* Walk through the list and check if URL starts with one of known protocols. */
 	foreach ( $protocols as $protocol ) {	


### PR DESCRIPTION
Was always getting missing or malformed url and just found that it's itms only.
How about we change that?